### PR TITLE
Fix: Refactor ParVagues header for responsiveness and style

### DIFF
--- a/next/components/ParVaguesHeader.js
+++ b/next/components/ParVaguesHeader.js
@@ -34,39 +34,38 @@ export default function ParVaguesHeader({ eventName = null, title = null }) {
     <header className="sticky top-0 left-0 w-full z-50 bg-black/80 backdrop-blur-md border-b border-[#d900ff]/20">
       <div className={`${styles.neonGradient} opacity-5 absolute inset-0`}></div>
       <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-        {/* Logo and Title with Navigation */}
-        <div className="flex items-center justify-between w-full">
-          <Link href="/parvagues" className="flex items-center group">
-            <div className="h-10 w-10 relative flex-shrink-0">
-              <Image 
-                src="/images/parvagues/logo.png" 
-                alt="ParVagues Logo" 
-                width={48}
-                height={48}
-                className="object-contain transition-all duration-300 group-hover:filter group-hover:drop-shadow-[0_0_8px_rgba(217,0,255,0.7)]" 
-              />
-            </div>
-            
-            <div className="overflow-hidden ml-2">
-              <span 
-                className={`text-white font-bold transition-all duration-500 ${
-                  showInHeader || !isHome ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-8'
-                }`}
-                style={{ 
-                  textShadow: '0 0 5px rgba(217, 0, 255, 0.7), 0 0 10px rgba(217, 0, 255, 0.5)',
-                  color: 'var(--neon-high)'
-                }}
-              >
-                {headerTitle}
-              </span>
-            </div>
-          </Link>
+        {/* Logo and Title */}
+        <Link href="/parvagues" className="flex items-center group">
+          <div className="h-10 w-10 relative flex-shrink-0">
+            <Image
+              src="/images/parvagues/logo.png"
+              alt="ParVagues Logo"
+              width={48}
+              height={48}
+              className="object-contain transition-all duration-300 group-hover:filter group-hover:drop-shadow-[0_0_8px_rgba(217,0,255,0.7)]"
+            />
+          </div>
           
-          {/* Navigation and CTA */}
-          <div className="flex items-center space-x-6">
-            {/* Navigation Links */}
-            <nav className="flex items-center space-x-6 text-sm tracking-wider">
-              <Link href="/parvagues#music" className="text-gray-300 hover:text-[#ff3d7b] transition-colors">
+          <div className="overflow-hidden ml-2">
+            <span
+              className={`text-white font-bold transition-all duration-500 ${
+                showInHeader || !isHome ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-8'
+              }`}
+              style={{
+                textShadow: '0 0 5px rgba(217, 0, 255, 0.7), 0 0 10px rgba(217, 0, 255, 0.5)',
+                color: 'var(--neon-high)'
+              }}
+            >
+              {headerTitle}
+            </span>
+          </div>
+        </Link>
+
+        {/* Navigation and CTA Container */}
+        <div className={`${styles.navAndCtaContainer} flex items-center space-x-6`}>
+          {/* Navigation Links */}
+          <nav className={`${styles.headerNavLinks} flex items-center space-x-6 text-sm tracking-wider`}>
+            <Link href="/parvagues#music" className="text-gray-300 hover:text-[#ff3d7b] transition-colors">
                 Music
               </Link>
               <Link href="/parvagues#performances" className="text-gray-300 hover:text-[#ff3d7b] transition-colors">
@@ -85,7 +84,7 @@ export default function ParVaguesHeader({ eventName = null, title = null }) {
               <FaEnvelope className="mr-2 flex-shrink-0" />
               <span>Book</span>
             </Link>
-          </div>
+          {/* End Navigation and CTA Container */}
         </div>
       </div>
     </header>

--- a/next/styles/parvagues.module.css
+++ b/next/styles/parvagues.module.css
@@ -533,6 +533,46 @@
   filter: drop-shadow(0 0 10px rgba(217, 0, 255, 0.5));
 }
 
+/* Styles for Header Navigation and CTA */
+.navAndCtaContainer {
+  display: flex;
+  align-items: center;
+  /* Tailwind 'space-x-6' on the container in JS handles horizontal spacing between nav and button */
+}
+
+.headerNavLinks {
+  display: flex;
+  align-items: center;
+   /* Tailwind 'space-x-6' on the nav element in JS handles horizontal spacing for individual links */
+}
+
+/* Responsive adjustments for header navigation */
+@media (max-width: 768px) { /* Breakpoint for tablets and mobiles */
+  .navAndCtaContainer {
+    flex-direction: column;
+    align-items: flex-end; /* Align stacked items (nav block and button) to the right */
+    gap: 1rem; /* Space between the nav links block and the CTA button when stacked */
+    margin-top: 0.5rem; /* Add some space above when it stacks */
+     /* width: 100%; */ /* Optional: if it needs to span width for alignment */
+  }
+
+  .headerNavLinks {
+    flex-direction: column; /* Stack individual nav links */
+    align-items: flex-end; /* Align text of nav links to the right */
+    gap: 0.75rem; /* Space between stacked nav links */
+    width: 100%; /* Ensure it takes width to allow text alignment */
+  }
+
+  /* Adjust .outlineButton for stacked layout if needed */
+  .navAndCtaContainer .outlineButton { /* More specific selector for the button in header */
+    width: auto; /* Allow button to size to its content, or set to 100% if full-width desired */
+    padding: 0.75rem 1.5rem; /* Adjust padding for smaller screens if needed */
+    font-size: 0.875rem; /* Adjust font size for smaller screens if needed */
+    /* justify-content: center; */ /* Uncomment if width is 100% and text needs centering */
+  }
+}
+/* End Styles for Header Navigation and CTA */
+
 /* Shine animation for album covers 
 NOTE: KEPT HERE FOR REFERENCE, THESE ARE COPIED IN THE MAIN GLOBAL.CSS 
 AS MODULE CSS FORBIDS ROOT VARIABLES


### PR DESCRIPTION
The ParVagues subsite header was previously displaying navigation links and the 'Book' button incorrectly, with elements stuck to the left, unstyled, and the 'Book' button appearing on a new line.

This commit addresses these issues by:
1. Refactoring the `ParVaguesHeader.js` component structure to ensure a proper flexbox layout for the logo, navigation links, and the 'Book' button.
2. Updating `parvagues.module.css` with new styles and media queries to:
    - Display header elements in a single, styled line on larger screens.
    - Stack header elements cleanly on smaller screens (768px and below), aligning them to the right.
    - Ensure the 'Book' button is styled consistently and adapts to different screen sizes.

These changes result in a cleaner, more responsive UI for the ParVagues header, improving your experience across various devices.